### PR TITLE
Add command line arguments and output redirection support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.o
 daemonize
 
+scratch*

--- a/README.md
+++ b/README.md
@@ -1,19 +1,18 @@
 # daemonize
-##### Executes a program as detached from its parent
+## Detachedly execute a program from its parent
 
-----
+This utility allows programs to run as children of `init`, which can be useful
+if you don't care about a program's text output and you want to free the shell,
+as in cases of GUI programs.
 
-This program allows to run programs as children of init,
-it can be useful if you don't care about a program's text output
-and you want to free the shell, for example if you run a GUI program.
+## Usage
+### Build the program
 
-### How to use
+```
+make
+```
 
-#### Build the program
-
-`make`
-
-#### Run something with it
-
-`./daemonize program arg1 arg2 arg3 ...`
-
+### Run it with something
+```
+./daemonize program arg1 arg2 arg3 ...
+```

--- a/daemonize.c
+++ b/daemonize.c
@@ -35,6 +35,8 @@
 
 #define OPT_OUTRED 'o'
 #define OPT_ERRRED 'e'
+#define OPT_HELP 'h'
+#define OPT_VERSION 'v'
 
 /* 
  * FIXME: This will only work in GNU CPP, because of
@@ -51,6 +53,9 @@
 	} while (0)										
 
 static char *name;
+static char *version = "v0.1";
+
+static void print_usage(char **, struct option const *);
 
 
 int main(int argc, char **argv) {
@@ -69,10 +74,12 @@ int main(int argc, char **argv) {
 	} pargs = {"", DEVNULL, DEVNULL, NULL};
 
 	int optindex;
-	char const *shortopts = "+ o: e: c:";
+	char const *shortopts = "+ h v o: e:";
 	const struct option longopts[] = {
 		{"out", required_argument, NULL, OPT_OUTRED},
-		{"err", required_argument, NULL, OPT_ERRRED}
+		{"err", required_argument, NULL, OPT_ERRRED},
+		{"help", no_argument, NULL, OPT_HELP},
+		{"version", no_argument, NULL, OPT_VERSION},
 	};
 
 	name = argv[0];
@@ -87,6 +94,12 @@ int main(int argc, char **argv) {
 			case OPT_ERRRED:
 				strncpy(pargs.errred, optarg, NAME_MAX);
 				break;
+			case OPT_HELP:
+				print_usage(argv, longopts);
+				exit(EXIT_SUCCESS);
+			case OPT_VERSION:
+				puts(version);
+				exit(EXIT_SUCCESS);
 			case -1:
 			default:
 				break;
@@ -101,7 +114,7 @@ int main(int argc, char **argv) {
 	 * terminated by a null pointer. [...]»
 	 * So shall `pargs.arguments` actually point to the name of the file, and
 	 * not just the argument(s) coming next?
-	 **/
+	 */
 	// Copy the command filename from the first remaining non-option argument
 	if (optind < argc) {
 		strncpy(pargs.command, argv[optind], NAME_MAX);
@@ -157,4 +170,19 @@ int main(int argc, char **argv) {
 	}
 	
 	return EXIT_SUCCESS;
+}
+
+
+static void print_usage(char **argv, struct option const *longopts) {
+	printf(
+		"%s: [-%c --%s <filename>] [-%c --%s <filename>] <CMD>\n",
+		argv[0], longopts[0].val, longopts[0].name, longopts[1].val,
+		longopts[1].name
+	);
+	printf(
+		"%s: [-%c --%s]\n", argv[0], longopts[2].val, longopts[2].name
+	);
+	printf(
+		"%s: [-%c --%s]\n", argv[0], longopts[3].val, longopts[3].name
+	);
 }

--- a/daemonize.c
+++ b/daemonize.c
@@ -23,9 +23,11 @@
 #include <unistd.h>
 #include <signal.h>
 
+
 #ifndef DEVNULL
 #define DEVNULL "/dev/null"
 #endif /* DEVNULL */
+
 
 /* 
  * FIXME: This will only work in GNU CPP, because of
@@ -33,7 +35,7 @@
  */
 #define errx(fmt, ...)  do {						\
 		fprintf(stderr, "%s: ", name);				\
-		if (strlen(fmt)){							\
+		if (strlen(fmt)) {							\
 			fprintf(stderr, fmt, ##__VA_ARGS__);	\
 			fprintf(stderr, ": ");					\
 		}											\
@@ -45,8 +47,8 @@ static void print_usage();
 
 static char *name;
 
-int main(int argc, char **argv){
-	int fd;
+
+int main(int argc, char **argv) {
 	int old_errno;
 	pid_t child;
 	struct sigaction sa;
@@ -58,19 +60,19 @@ int main(int argc, char **argv){
 		return EXIT_SUCCESS;
 	}
 	
-	if ((child = fork()) == 0){
+	if ((child = fork()) == 0) {
 		/* Ignore SIGHUP */
 		memset(&sa, 0, sizeof(sa));
 		sa.sa_handler = SIG_IGN;
 		sigaction(SIGHUP, &sa, NULL);
 
 		/* Create a new session */
-		if (setsid() < 0){
+		if (setsid() < 0) {
 			errx("can't create a new session");
 		}
 
 		/* Redirect I/O to /dev/null open for writing */
-		if ((fd = open(DEVNULL, O_WRONLY)) < 0){
+		if ((fd = open(DEVNULL, O_WRONLY)) < 0) {
 			errx("can't open %s", DEVNULL);
 		}
 
@@ -87,14 +89,14 @@ int main(int argc, char **argv){
 		}
 
 		/* Execute target command */
-		if (execvp(argv[1], &argv[1]) < 0){
+		if (execvp(argv[1], &argv[1]) < 0) {
 			/* close() may alter errno */
 			old_errno = errno;
 			close(fd);
 			errno = old_errno;
 			errx("can't exec");
 		}
-	} else if (child < 0){
+	} else if (child < 0) {
 		errx("fork");
 	}
 	


### PR DESCRIPTION
This PR is primarily intended to provide redirection support to `daemonize` through the GNU `getopt_long()` utility. Since I was at it anyway, I also considered to spruce up the source code and `README.md` with some other fanciness.

**Please note**: close this PR only after I agree to do so - there is yet some code to test and verify. in the meanwhile, feel free to review the PR contents and merge them.